### PR TITLE
Removed preceding slash for all paths

### DIFF
--- a/tasks/blanket_mocha_server.coffee
+++ b/tasks/blanket_mocha_server.coffee
@@ -53,7 +53,7 @@ module.exports = (grunt) ->
     obj[prop] = path.resolve obj[prop]
     minViolationTest obj, prop
 
-    preNodeModulesMatch = obj[prop].match /^(.*)\/node_modules\/.*$/
+    preNodeModulesMatch = obj[prop].match /^(.*\/)node_modules\/.*$/
     if preNodeModulesMatch
       obj[prop] = obj[prop].replace preNodeModulesMatch[1], ''
     else
@@ -100,7 +100,7 @@ module.exports = (grunt) ->
       # passed the tests -- no clean up the dir base
       _.each obj[prop], (val, index) ->
         obj[prop][index] = path.resolve(val)
-            .replace(path.resolve(process.cwd()), '')
+            .replace(path.resolve(process.cwd()) + '/', '')
             .replace(/[\\]/g, '/')
 
     undefined


### PR DESCRIPTION
Removed preceding slash for all paths to enable using generated environment without and with server. Not sure if this was the best way to do it, but worked within the my time constraints.
